### PR TITLE
Music notifier with mpris  

### DIFF
--- a/basic-rng.rs
+++ b/basic-rng.rs
@@ -1,0 +1,45 @@
+use rand::Rng;
+use std::io::{stdin, stdout, Write};
+extern crate colored;
+use colored::*;
+use std::{thread, time};
+#[allow(unused_macros)]
+macro_rules! read {
+    ($var:ident as $data_type:ty) => {
+        let mut tmp = String::new();
+
+        stdin().read_line(&mut tmp).expect("some prob hapend");
+
+        let $var = tmp.trim().parse::<$data_type>().expect("some prob hapend");
+    };
+}
+fn random(min: u64, max: u64) -> u64 {
+    rand::thread_rng().gen_range(min..max)
+}
+fn main() {
+    let mut count = 0;
+    let mut stdout = stdout();
+    let three_sec = time::Duration::from_secs(3);
+    eprint!("enter minimum value: ");
+    read!(a as u64);
+    eprint!("enter maximum value: ");
+    read!(b as u64);
+    eprint!("enter the number u wanna find: ");
+    read!(num as i128);
+    loop {
+        let number = random(a, b);
+        print!("\r{} {}", "random number: ".red(), number);
+        if i128::from(number) == num {
+            print!("\r");
+            println!(
+                "\rThe number we waited for is here {:?} after {:?} times",
+                number, count
+            );
+            thread::sleep(three_sec);
+            break;
+        } else {
+            count += 1;
+            stdout.flush().unwrap();
+        }
+    }
+}

--- a/now_playing.rs
+++ b/now_playing.rs
@@ -1,0 +1,44 @@
+use mpris::PlayerFinder;
+use notify_rust::Notification;
+fn main() {
+    let player = PlayerFinder::new()
+        .expect("Could not connect to D-Bus")
+        .find_active()
+        .expect("Could not find active player");
+
+    println!(
+        "Showing event stream for player {}...\n(Exit with Ctrl-C)\n",
+        player.identity()
+    );
+
+    let events = player.events().expect("Could not start event stream");
+
+    for event in events {
+        match event {
+            Ok(event) => match event {
+                mpris::Event::TrackChanged(metadata) => {
+                    if !metadata.art_url().unwrap().is_empty()
+                        && metadata.track_id().is_some()
+                        && !metadata.title().unwrap().is_empty()
+                    {
+                        let _ = Notification::new()
+                            .summary("Now playing")
+                            .body(metadata.title().unwrap())
+                            .icon("emblem-music-symbolic")
+                            .show();
+                    } else {
+                        continue;
+                    };
+                }
+                _ => {}
+            },
+            Err(err) => {
+                println!("D-Bus error: {}. Aborting.", err);
+                break;
+            }
+        }
+    }
+
+    println!("Event stream ended.");
+}
+


### PR DESCRIPTION
_This pr adds a background service that notifies the user whenever there is some music is playing_

**Key features:**

- Uses widely used standard (mpris)
- supports art covers 
- with some tweaking may work on windows

**Error Handling:** 

- service handles availablility of dbus and mpris
Assign me to the hacktoberfest.