### PR TITLE
feat(js): add client-side Image Compressor (Canvas API, WEBP/JPEG)

### DIFF
--- a/Image-Compressor-In-Javascript/.vscode/settings.json
+++ b/Image-Compressor-In-Javascript/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/Image-Compressor-In-Javascript/README.md
+++ b/Image-Compressor-In-Javascript/README.md
@@ -1,0 +1,26 @@
+# Image Compressor (Client-side)
+
+A tiny, dependency-free tool to compress and resize images in the browser.  
+- Choose an image
+- Set quality and max dimensions
+- Preview original vs compressed
+- Download the result (WEBP if supported, otherwise JPEG)
+
+## Run
+Just open `index.html` in a browser (no build step).
+
+## Files
+- `index.html` – markup and controls
+- `styles.css` – minimal UI
+- `script.js` – compression logic (Canvas API)
+
+## How it works
+1. Read the file with an `<input type="file">`
+2. Draw to `<canvas>` (optionally scaled down)
+3. Export via `canvas.toBlob(type, quality)` to WEBP/JPEG
+4. Trigger a download with an `<a download>` link
+
+## Notes
+- Uses `URL.createObjectURL` to preview and download.
+- Chooses WEBP when supported; falls back to JPEG.
+- No external libraries.

--- a/Image-Compressor-In-Javascript/index.html
+++ b/Image-Compressor-In-Javascript/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Image Compressor (Client-side)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header>
+    <h1>Image Compressor (Client-side)</h1>
+    <input id="file" type="file" accept="image/*" />
+  </header>
+
+  <section class="card">
+    <div class="controls">
+      <label>Quality (JPEG/WEBP)
+        <input id="quality" type="range" min="0.1" max="1" step="0.05" value="0.7" />
+      </label>
+      <label>Max Width (px)
+        <input id="maxW" type="number" min="64" max="6000" value="1600" />
+      </label>
+      <label>Max Height (px)
+        <input id="maxH" type="number" min="64" max="6000" value="1600" />
+      </label>
+    </div>
+    <div class="actions">
+      <button id="compress">Compress</button>
+      <button id="download" class="secondary" disabled>Download</button>
+      <button id="reset" class="secondary">Reset</button>
+    </div>
+  </section>
+
+  <section class="row">
+    <figure class="card">
+      <strong>Original</strong>
+      <div class="meta" id="origMeta" aria-live="polite">No file.</div>
+      <img id="preview" alt="Original preview" />
+    </figure>
+    <figure class="card">
+      <strong>Compressed</strong>
+      <div class="meta" id="outMeta" aria-live="polite">—</div>
+      <canvas id="canvas" class="muted"></canvas>
+    </figure>
+  </section>
+
+  <script src="./script.js"></script>
+</body>
+</html>

--- a/Image-Compressor-In-Javascript/script.js
+++ b/Image-Compressor-In-Javascript/script.js
@@ -1,0 +1,91 @@
+const fileInput = document.getElementById('file');
+    const qualityEl = document.getElementById('quality');
+    const maxWEl = document.getElementById('maxW');
+    const maxHEl = document.getElementById('maxH');
+    const compressBtn = document.getElementById('compress');
+    const downloadBtn = document.getElementById('download');
+    const resetBtn = document.getElementById('reset');
+    const previewImg = document.getElementById('preview');
+    const canvas = document.getElementById('canvas');
+    const origMeta = document.getElementById('origMeta');
+    const outMeta = document.getElementById('outMeta');
+
+    let originalFile = null;
+    let outBlob = null;
+
+    function fmtBytes(b){
+      if(!b && b!==0) return '—';
+      const u=['B','KB','MB','GB']; let i=0;
+      while(b>=1024 && i<u.length-1){b/=1024;i++}
+      return b.toFixed(b<10&&i>0?2:0)+' '+u[i];
+    }
+
+    function loadImage(file){
+      return new Promise((resolve,reject)=>{
+        const url = URL.createObjectURL(file);
+        const img = new Image();
+        img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
+        img.onerror = reject;
+        img.src = url;
+      });
+    }
+
+    async function compress(){
+      if(!originalFile){ alert('Please choose an image first.'); return; }
+      const img = await loadImage(originalFile);
+      const maxW = parseInt(maxWEl.value||1600,10);
+      const maxH = parseInt(maxHEl.value||1600,10);
+      let { width:w, height:h } = img;
+
+      // Constrain to bounding box while keeping aspect ratio
+      const ratio = Math.min(maxW / w, maxH / h, 1);
+      const cw = Math.round(w * ratio), ch = Math.round(h * ratio);
+
+      canvas.width = cw; canvas.height = ch;
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0,0,cw,ch);
+      ctx.drawImage(img, 0, 0, cw, ch);
+
+      const q = parseFloat(qualityEl.value||0.7);
+      // Prefer WebP when supported; fallback to JPEG
+      const type = canvas.toDataURL('image/webp', q).startsWith('data:image/webp') ? 'image/webp' : 'image/jpeg';
+
+      outBlob = await new Promise(res=>canvas.toBlob(res, type, q));
+      canvas.classList.remove('muted');
+
+      outMeta.textContent = `Size: ${fmtBytes(outBlob.size)} • Type: ${type.replace('image/','').toUpperCase()} • ${cw}×${ch}`;
+      downloadBtn.disabled = false;
+    }
+
+    function reset(){
+      originalFile = null; outBlob = null;
+      previewImg.src = ''; canvas.width = canvas.height = 0;
+      origMeta.textContent = 'No file.'; outMeta.textContent = '—';
+      canvas.classList.add('muted'); downloadBtn.disabled = true;
+      fileInput.value = ''; qualityEl.value = 0.7; maxWEl.value = 1600; maxHEl.value = 1600;
+    }
+
+    fileInput.addEventListener('change', async (e)=>{
+      const f = e.target.files[0];
+      if(!f) return;
+      if(!f.type.startsWith('image/')){ alert('Please select an image file.'); reset(); return; }
+      originalFile = f;
+      previewImg.src = URL.createObjectURL(f);
+      origMeta.textContent = `Size: ${fmtBytes(f.size)} • Type: ${f.type || 'image'} `;
+      outMeta.textContent = '—'; canvas.classList.add('muted'); downloadBtn.disabled = true;
+    });
+
+    compressBtn.addEventListener('click', compress);
+
+    downloadBtn.addEventListener('click', ()=>{
+      if(!outBlob) return;
+      const a = document.createElement('a');
+      const name = (originalFile?.name || 'image').replace(/\.(\w+)$/,'');
+      const ext = (outBlob.type.includes('webp') ? 'webp' : 'jpg');
+      a.href = URL.createObjectURL(outBlob);
+      a.download = `${name}.compressed.${ext}`;
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(()=>URL.revokeObjectURL(a.href), 1000);
+    });
+
+    resetBtn.addEventListener('click', reset);

--- a/Image-Compressor-In-Javascript/style.css
+++ b/Image-Compressor-In-Javascript/style.css
@@ -1,0 +1,16 @@
+ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;max-width:900px;margin:24px auto;padding:0 16px;line-height:1.4}
+    header{display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap}
+    h1{font-size:1.25rem;margin:0}
+    .row{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px}
+    .card{border:1px solid #ddd;border-radius:12px;padding:12px}
+    .controls{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:12px}
+    label{font-size:.9rem;color:#444}
+    input[type="number"],input[type="range"]{width:100%}
+    button{padding:10px 12px;border-radius:10px;border:1px solid #333;background:#111;color:#fff;cursor:pointer}
+    button.secondary{background:#fff;color:#111}
+    .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
+    figure{margin:0;display:flex;flex-direction:column;gap:8px}
+    .meta{font-size:.85rem;color:#555}
+    canvas,img{max-width:100%;border-radius:8px;border:1px dashed #bbb;background:#fafafa}
+    .muted{opacity:.8}
+    @media (max-width:800px){.row{grid-template-columns:1fr} .controls{grid-template-columns:1fr}}


### PR DESCRIPTION
### What I did
- Added `JavaScript/ImageCompressor` with index.html, styles.css, script.js, README.md
- Features: preview original vs compressed, max width/height, quality slider, WEBP/JPEG fallback, download

### Why
- Useful, dependency-free example of Canvas API + file handling

### Test notes
- Works on file://, Live Server, and python http.server
- Verified WebP support + JPEG fallback

### Checklist
- [x] Follows repo structure
- [x] README included
- [x] No duplicate project
<img width="1505" height="778" alt="Screenshot 2025-10-23 at 5 19 07 PM" src="https://github.com/user-attachments/assets/8fb31d69-04f3-443f-b467-408dc6c9bc42" />

